### PR TITLE
Add support for remapping table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,8 @@ generator zero {
   // By default, the generator will keep track of changes to the schema and automatically bump the version.
   // You can opt-out from this behavior by setting `schemaVersion`.
   schemaVersion = 10
+  // When true, the generator will remap table names to camel case using Zero's `.from()` method.
+  // You can read more about it here https://zero.rocicorp.dev/docs/zero-schema#name-mapping
+  remapTablesToCamelCase = true
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/generator-helper": "^5.20.0"
+        "@prisma/generator-helper": "^5.20.0",
+        "change-case": "^5.4.4"
       },
       "bin": {
         "prisma-generator-zero": "dist/generator.js"
@@ -863,6 +864,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
     },
     "node_modules/check-error": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/Passionfroot/prisma-generator-zero#readme",
   "dependencies": {
-    "@prisma/generator-helper": "^5.20.0"
+    "@prisma/generator-helper": "^5.20.0",
+    "change-case": "^5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/src/__tests__/schemaMapper.test.ts
+++ b/src/__tests__/schemaMapper.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { transformSchema } from "../mappers/schemaMapper";
+import { createModel, createField, createMockDMMF } from "./utils";
+import type { Config } from "../types";
+
+describe("Schema Mapper", () => {
+  describe("remapTablesToCamelCase", () => {
+    const baseConfig: Config = {
+      name: "test",
+      prettier: false,
+      resolvePrettierConfig: false,
+      remapTablesToCamelCase: false,
+    };
+
+    it("should not remap table names when remapTablesToCamelCase is false", () => {
+      const model = createModel("UserProfile", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ]);
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, baseConfig);
+
+      expect(result.models[0].tableName).toBe("UserProfile");
+      expect(result.models[0].originalTableName).toBeUndefined();
+    });
+
+    it("should remap table names to camel case when remapTablesToCamelCase is true", () => {
+      const model = createModel("UserProfile", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ]);
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      expect(result.models[0].tableName).toBe("userProfile");
+      expect(result.models[0].originalTableName).toBe("UserProfile");
+    });
+
+    it("should preserve table name if already in camel case", () => {
+      const model = createModel("userProfile", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ]);
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      expect(result.models[0].tableName).toBe("userProfile");
+      expect(result.models[0].originalTableName).toBeUndefined();
+    });
+
+    it("should handle table names with underscores", () => {
+      const model = createModel("User", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ], {
+        dbName: "user_profile"
+      });
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      expect(result.models[0].tableName).toBe("userProfile");
+      expect(result.models[0].originalTableName).toBe("user_profile");
+    });
+
+    it("should handle table names with multiple underscores", () => {
+      const model = createModel("User", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ], {
+        dbName: "user_profile_settings"
+      });
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      expect(result.models[0].tableName).toBe("userProfileSettings");
+      expect(result.models[0].originalTableName).toBe("user_profile_settings");
+    });
+
+    it("should preserve leading underscores", () => {
+      const model = createModel("UserProfile", [
+        createField("id", "String", { isId: true }),
+        createField("name", "String"),
+      ], {
+        dbName: "_UserProfile"
+      });
+
+      const dmmf = createMockDMMF([model]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      expect(result.models[0].tableName).toBe("_userProfile");
+      expect(result.models[0].originalTableName).toBe("_UserProfile");
+    });
+
+    it("should handle implicit many-to-many join tables", () => {
+      const postModel = createModel("Post", [
+        createField("id", "String", { isId: true }),
+        createField("categories", "Category", { 
+          isList: true,
+          relationName: "PostToCategory",
+          kind: "object"
+        }),
+      ]);
+
+      const categoryModel = createModel("Category", [
+        createField("id", "String", { isId: true }),
+        createField("posts", "Post", { 
+          isList: true,
+          relationName: "PostToCategory",
+          kind: "object"
+        }),
+      ]);
+
+      const dmmf = createMockDMMF([postModel, categoryModel]);
+      const result = transformSchema(dmmf, 1, {
+        ...baseConfig,
+        remapTablesToCamelCase: true,
+      });
+
+      // Find the join table (note: the join table name is based on the relation name)
+      const joinTable = result.models.find(m => m.modelName === "_PostToCategory");
+      expect(joinTable).toBeDefined();
+      if (joinTable) {
+        expect(joinTable.tableName).toBe("_postToCategory");
+        expect(joinTable.originalTableName).toBe("_PostToCategory");
+      }
+    });
+  });
+}); 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -23,6 +23,7 @@ export async function onGenerate(options: GeneratorOptions) {
     schemaVersion: generator.config.schemaVersion
       ? Number(generator.config.schemaVersion)
       : undefined,
+    remapTablesToCamelCase: generator.config.remapTablesToCamelCase === "true", // Default false
   } satisfies Config;
 
   // Get current version and hash
@@ -32,7 +33,7 @@ export async function onGenerate(options: GeneratorOptions) {
   );
 
   // Transform the schema
-  const transformedSchema = transformSchema(dmmf, currentVersion);
+  const transformedSchema = transformSchema(dmmf, currentVersion, config);
 
   // Calculate next version
   const nextVersion = calculateNextVersion(

--- a/src/generators/codeGenerator.ts
+++ b/src/generators/codeGenerator.ts
@@ -37,8 +37,14 @@ function generateColumnDefinition(name: string, mapping: ZeroTypeMapping): strin
 }
 
 function generateModelSchema(model: ZeroModel): string {
-  let output = `export const ${model.zeroTableName} = table("${model.tableName}")\n`;
-  output += "  .columns({\n";
+  let output = `export const ${model.zeroTableName} = table("${model.tableName}")`;
+  
+  // Add .from() if we have an original table name
+  if (model.originalTableName) {
+    output += `\n  .from("${model.originalTableName}")`;
+  }
+  
+  output += "\n  .columns({\n";
 
   Object.entries(model.columns).forEach(([name, mapping]) => {
     output += generateColumnDefinition(name, mapping) + ",\n";

--- a/src/mappers/schemaMapper.ts
+++ b/src/mappers/schemaMapper.ts
@@ -1,7 +1,8 @@
 import type { DMMF } from "@prisma/generator-helper";
-import { ZeroModel, ZeroRelationship, TransformedSchema } from "../types";
+import { ZeroModel, ZeroRelationship, TransformedSchema, Config } from "../types";
 import { mapPrismaTypeToZero } from "./typeMapper";
 import { generateSchemaHash } from "../utils/hash";
+import { camelCase } from "change-case";
 
 function getTableName(model: DMMF.Model): string {
   return model.dbName || model.name;
@@ -31,13 +32,22 @@ function getImplicitManyToManyTableName(model1: string, model2: string, relation
 function createImplicitManyToManyModel(
   model1: DMMF.Model,
   model2: DMMF.Model,
-  relationName?: string
+  relationName?: string,
+  config?: Config
 ): ZeroModel {
   const tableName = getImplicitManyToManyTableName(model1.name, model2.name, relationName);
   const [modelA, modelB] = [model1, model2].sort((a, b) => a.name.localeCompare(b.name));
   
+  // Apply camel case transformation if config is provided and remapTablesToCamelCase is true
+  const camelCasedName = config?.remapTablesToCamelCase ? camelCase(tableName, {
+    prefixCharacters: "_",
+  }) : tableName;
+  
+  const shouldRemap = config?.remapTablesToCamelCase && camelCasedName !== tableName;
+  
   return {
-    tableName,
+    tableName: shouldRemap ? camelCasedName : tableName,
+    originalTableName: shouldRemap ? tableName : undefined,
     modelName: tableName,
     zeroTableName: getZeroTableName(tableName),
     columns: {
@@ -152,7 +162,7 @@ function mapRelationships(
   return Object.keys(relationships).length > 0 ? relationships : undefined;
 }
 
-function mapModel(model: DMMF.Model, dmmf: DMMF.Document): ZeroModel {
+function mapModel(model: DMMF.Model, dmmf: DMMF.Document, config: Config): ZeroModel {
   const columns: Record<string, ReturnType<typeof mapPrismaTypeToZero>> = {};
 
   model.fields
@@ -167,8 +177,16 @@ function mapModel(model: DMMF.Model, dmmf: DMMF.Document): ZeroModel {
     throw new Error(`No primary key found for ${model.name}`);
   }
 
+  const tableName = getTableName(model);
+  const camelCasedName = camelCase(tableName, {
+    prefixCharacters: "_",
+  });
+  
+  const shouldRemap = config.remapTablesToCamelCase && camelCasedName !== tableName;
+
   return {
-    tableName: getTableName(model),
+    tableName: shouldRemap ? camelCasedName : tableName,
+    originalTableName: shouldRemap ? tableName : undefined,
     modelName: model.name,
     zeroTableName: getZeroTableName(model.name),
     columns,
@@ -177,10 +195,10 @@ function mapModel(model: DMMF.Model, dmmf: DMMF.Document): ZeroModel {
   };
 }
 
-export function transformSchema(dmmf: DMMF.Document, currentVersion: number): TransformedSchema {
-  const models = dmmf.datamodel.models.map((model) => mapModel(model, dmmf));
+export function transformSchema(dmmf: DMMF.Document, currentVersion: number, config: Config): TransformedSchema {
+  const models = dmmf.datamodel.models.map((model) => mapModel(model, dmmf, config));
   
-  // Add implicit many-to-many join tables
+  // Add implicit many-to-many join tables (but don't include them in the final schema)
   const implicitJoinTables = dmmf.datamodel.models.flatMap((model) => {
     return model.fields
       .filter((field) => field.relationName && field.isList)
@@ -195,7 +213,7 @@ export function transformSchema(dmmf: DMMF.Document, currentVersion: number): Tr
         if (backReference?.isList) {
           // Only create the join table once for each relationship
           if (model.name.localeCompare(targetModel.name) < 0) {
-            return createImplicitManyToManyModel(model, targetModel, field.relationName);
+            return createImplicitManyToManyModel(model, targetModel, field.relationName, config);
           }
         }
         return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Config = {
   prettier: boolean;
   resolvePrettierConfig: boolean;
   schemaVersion?: number;
+  remapTablesToCamelCase: boolean;
 };
 
 export type SchemaVersion = {
@@ -38,6 +39,7 @@ export type ZeroRelationship = {
 
 export type ZeroModel = {
   tableName: string;
+  originalTableName?: string;
   modelName: string;
   zeroTableName: string;
   columns: Record<string, ZeroTypeMapping>;


### PR DESCRIPTION
Zero added support for remapping table names using `.from()` in `v0.14` - this allows to convert something like `UserSettings` to `userSettings` which makes for much cleaner code when using `z.query`

This PR adds support for automatic remappings. To enable it, add `remapTablesToCamelCase = true` to the prisma generator (or see `README.md` for more info