### PR TITLE
Filter out unsupported columns and add `excludeTables`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,9 @@ generator zero {
   // When true, the generator will remap table names to camel case using Zero's `.from()` method.
   // You can read more about it here https://zero.rocicorp.dev/docs/zero-schema#name-mapping
   remapTablesToCamelCase = true
+  // Optional list of Prisma Model names you want to exclude from the generated schema.
+  // Helpful if you want to exclude Views (not supported by Zero) or other tables
+  // you don't want Zero client to have access to
+  excludeTables = ["Posts", "Comments", ...]
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@passionfroot/prisma-generator-zero",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@passionfroot/prisma-generator-zero",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@prisma/generator-helper": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passionfroot/prisma-generator-zero",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Prisma generator for generating Zero schema with ease",
   "main": "./dist/generator.js",
   "bin": {

--- a/src/__tests__/__snapshots__/generator.test.ts.snap
+++ b/src/__tests__/__snapshots__/generator.test.ts.snap
@@ -21,7 +21,6 @@ export const postTable = table("Post")
   .columns({
     id: number(),
     title: string(),
-    categories: string(),
   })
   .primaryKey("id");
 
@@ -29,7 +28,6 @@ export const categoryTable = table("Category")
   .columns({
     id: number(),
     name: string(),
-    posts: string(),
   })
   .primaryKey("id");
 

--- a/src/__tests__/schemaMapper.test.ts
+++ b/src/__tests__/schemaMapper.test.ts
@@ -4,14 +4,104 @@ import { createModel, createField, createMockDMMF } from "./utils";
 import type { Config } from "../types";
 
 describe("Schema Mapper", () => {
-  describe("remapTablesToCamelCase", () => {
-    const baseConfig: Config = {
-      name: "test",
-      prettier: false,
-      resolvePrettierConfig: false,
-      remapTablesToCamelCase: false,
-    };
+  const baseConfig: Config = {
+    name: "test",
+    prettier: false,
+    resolvePrettierConfig: false,
+    remapTablesToCamelCase: false,
+  };
 
+  describe("excludeTables", () => {
+    it("should exclude specified tables from the schema", () => {
+      const models = [
+        createModel("User", [
+          createField("id", "String", { isId: true }),
+          createField("name", "String"),
+        ]),
+        createModel("Post", [
+          createField("id", "String", { isId: true }),
+          createField("title", "String"),
+        ]),
+        createModel("Comment", [
+          createField("id", "String", { isId: true }),
+          createField("content", "String"),
+        ]),
+      ];
+
+      const dmmf = createMockDMMF(models);
+      const result = transformSchema(dmmf, {
+        ...baseConfig,
+        excludeTables: ["Post", "Comment"],
+      });
+
+      expect(result.models).toHaveLength(1);
+      expect(result.models[0].tableName).toBe("User");
+    });
+
+    it("should exclude many-to-many relationships involving excluded tables", () => {
+      const models = [
+        createModel("User", [
+          createField("id", "String", { isId: true }),
+          createField("name", "String"),
+          createField("posts", "Post", { isList: true, relationName: "UserPosts" }),
+        ]),
+        createModel("Post", [
+          createField("id", "String", { isId: true }),
+          createField("title", "String"),
+          createField("users", "User", { isList: true, relationName: "UserPosts" }),
+        ]),
+      ];
+
+      const dmmf = createMockDMMF(models);
+      const result = transformSchema(dmmf, {
+        ...baseConfig,
+        excludeTables: ["Post"],
+      });
+
+      expect(result.models).toHaveLength(1);
+      expect(result.models[0].tableName).toBe("User");
+      // The implicit many-to-many join table should not be included
+      expect(result.models.find((m) => m.tableName === "_UserPosts")).toBeUndefined();
+    });
+
+    it("should exclude relationship fields from excluded tables", () => {
+      const models = [
+        createModel("User", [
+          createField("id", "String", { isId: true }),
+          createField("name", "String"),
+          createField("profile", "Profile", { relationName: "UserProfile" }),
+          createField("posts", "Post", { relationName: "UserPosts" }),
+        ]),
+        createModel("Post", [
+          createField("id", "String", { isId: true }),
+          createField("title", "String"),
+          createField("users", "User", { isList: true, relationName: "UserPosts" }),
+        ]),
+        createModel("Profile", [
+          createField("id", "String", { isId: true }),
+          createField("bio", "String"),
+          createField("user", "User", { relationName: "UserProfile" }),
+        ]),
+      ];
+
+      const dmmf = createMockDMMF(models);
+      const result = transformSchema(dmmf, {
+        ...baseConfig,
+        excludeTables: ["Post"],
+      });
+
+      const userModel = result.models.find((m) => m.tableName === "User");
+      expect(userModel).toBeDefined();
+      if (userModel) {
+        // Verify that the posts relationship field is not included
+        expect(userModel.relationships).not.toHaveProperty("posts");
+        // Verify that the profile relationship field is still included
+        expect(userModel.relationships).toHaveProperty("profile");
+      }
+    });
+  });
+
+  describe("remapTablesToCamelCase", () => {
     it("should not remap table names when remapTablesToCamelCase is false", () => {
       const model = createModel("UserProfile", [
         createField("id", "String", { isId: true }),
@@ -58,12 +148,13 @@ describe("Schema Mapper", () => {
     });
 
     it("should handle table names with underscores", () => {
-      const model = createModel("User", [
-        createField("id", "String", { isId: true }),
-        createField("name", "String"),
-      ], {
-        dbName: "user_profile"
-      });
+      const model = createModel(
+        "User",
+        [createField("id", "String", { isId: true }), createField("name", "String")],
+        {
+          dbName: "user_profile",
+        }
+      );
 
       const dmmf = createMockDMMF([model]);
       const result = transformSchema(dmmf, {
@@ -76,12 +167,13 @@ describe("Schema Mapper", () => {
     });
 
     it("should handle table names with multiple underscores", () => {
-      const model = createModel("User", [
-        createField("id", "String", { isId: true }),
-        createField("name", "String"),
-      ], {
-        dbName: "user_profile_settings"
-      });
+      const model = createModel(
+        "User",
+        [createField("id", "String", { isId: true }), createField("name", "String")],
+        {
+          dbName: "user_profile_settings",
+        }
+      );
 
       const dmmf = createMockDMMF([model]);
       const result = transformSchema(dmmf, {
@@ -94,12 +186,13 @@ describe("Schema Mapper", () => {
     });
 
     it("should preserve leading underscores", () => {
-      const model = createModel("UserProfile", [
-        createField("id", "String", { isId: true }),
-        createField("name", "String"),
-      ], {
-        dbName: "_UserProfile"
-      });
+      const model = createModel(
+        "UserProfile",
+        [createField("id", "String", { isId: true }), createField("name", "String")],
+        {
+          dbName: "_UserProfile",
+        }
+      );
 
       const dmmf = createMockDMMF([model]);
       const result = transformSchema(dmmf, {
@@ -114,19 +207,19 @@ describe("Schema Mapper", () => {
     it("should handle implicit many-to-many join tables", () => {
       const postModel = createModel("Post", [
         createField("id", "String", { isId: true }),
-        createField("categories", "Category", { 
+        createField("categories", "Category", {
           isList: true,
           relationName: "PostToCategory",
-          kind: "object"
+          kind: "object",
         }),
       ]);
 
       const categoryModel = createModel("Category", [
         createField("id", "String", { isId: true }),
-        createField("posts", "Post", { 
+        createField("posts", "Post", {
           isList: true,
           relationName: "PostToCategory",
-          kind: "object"
+          kind: "object",
         }),
       ]);
 
@@ -137,7 +230,7 @@ describe("Schema Mapper", () => {
       });
 
       // Find the join table (note: the join table name is based on the relation name)
-      const joinTable = result.models.find(m => m.modelName === "_PostToCategory");
+      const joinTable = result.models.find((m) => m.modelName === "_PostToCategory");
       expect(joinTable).toBeDefined();
       if (joinTable) {
         expect(joinTable.tableName).toBe("_postToCategory");
@@ -145,4 +238,4 @@ describe("Schema Mapper", () => {
       }
     });
   });
-}); 
+});

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,4 @@
-import { generatorHandler, GeneratorOptions } from "@prisma/generator-helper";
+import { GeneratorConfig, generatorHandler, GeneratorOptions } from "@prisma/generator-helper";
 import { writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { version } from "../package.json";
@@ -20,6 +20,7 @@ export async function onGenerate(options: GeneratorOptions) {
     prettier: generator.config.prettier === "true", // Default false,
     resolvePrettierConfig: generator.config.resolvePrettierConfig !== "false", // Default true
     remapTablesToCamelCase: generator.config.remapTablesToCamelCase === "true", // Default false
+    excludeTables: loadExcludeTables(generator),
   } satisfies Config;
 
   // Transform the schema
@@ -59,3 +60,20 @@ generatorHandler({
   },
   onGenerate,
 });
+
+/**
+ * Load the excludeTables from the generator config
+ */
+function loadExcludeTables(generator: GeneratorConfig) {
+  const value = generator.config.excludeTables;
+
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error("excludeTables must be an array");
+  }
+
+  return value;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Config = {
   prettier: boolean;
   resolvePrettierConfig: boolean;
   remapTablesToCamelCase: boolean;
+  excludeTables?: string[];
 };
 
 export type ZeroTypeMapping = {


### PR DESCRIPTION
- In Zero v0.17, the schema must only contain supported column types or Zero will detect the schema as incompatible and will keep reloading the app (more [here](https://discord.com/channels/830183651022471199/1350524509635084299)). This change automatically removes unsupported columns from the generated schema.
- Added `excludeTables` config for the generator to allow filtering out specific tables/views from the generated schema. Resolves #22, #23