### PR TITLE
Fix composite keys definition

### DIFF
--- a/src/mappers/schemaMapper.ts
+++ b/src/mappers/schemaMapper.ts
@@ -157,8 +157,10 @@ function mapRelationships(
           };
         } else {
           // Regular one-to-many relationship
+          // Use primaryKey fields first (for @@id), fallback to isId field (for @id)
           const idField = model.fields.find((f) => f.isId)?.name;
-          const sourceFields = idField ? [idField] : [];
+          const primaryKeyFields = model.primaryKey?.fields || (idField ? [idField] : []);
+          const sourceFields = ensureStringArray(primaryKeyFields);
           const destFields = backReference?.relationFromFields
             ? ensureStringArray(backReference.relationFromFields)
             : [];


### PR DESCRIPTION
Fix an issue causing composite primary keys defined using `@@id` (docs [here](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#id-1)) to not be correctly defined in Zero schema